### PR TITLE
GEOIN-194

### DIFF
--- a/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -248,6 +248,17 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
     }
 
     /// <summary>
+    /// Seed terra-draw with an existing GeoJSON feature and switch into select
+    /// mode so the user can edit its coordinates.
+    /// </summary>
+    /// <param name="featureJson">GeoJSON Feature serialized as JSON.</param>
+    /// <param name="mode">Terra-draw mode of the feature ("point" | "linestring" | "polygon").</param>
+    public async Task EditTerraDrawFeatureAsync(string featureJson, string mode)
+    {
+        await _jsModule.InvokeVoidAsync("editTerraDrawFeature", MapId, featureJson, mode);
+    }
+
+    /// <summary>
     /// Finish / Close the geometry being edited (simulates enter-key event)
     /// </summary>
     public async Task FinishGeometryAsync()

--- a/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -251,6 +251,13 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
     /// Seed terra-draw with an existing GeoJSON feature and switch into select
     /// mode so the user can edit its coordinates.
     /// </summary>
+    /// <remarks>
+    /// While this edit session is active, <see cref="GetTerraDrawGeometriesAsync"/>
+    /// returns only the seeded feature. The session ends when the user switches to
+    /// a non-select mode (e.g. via the drawing toolbar) or when <see cref="StopTerraDrawAsync"/>
+    /// is called. Calling <c>EditTerraDrawFeatureAsync</c> again replaces the
+    /// previously seeded feature in terra-draw's store.
+    /// </remarks>
     /// <param name="featureJson">GeoJSON Feature serialized as JSON.</param>
     /// <param name="mode">Terra-draw mode of the feature ("point" | "linestring" | "polygon").</param>
     public async Task EditTerraDrawFeatureAsync(string featureJson, string mode)

--- a/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -4,6 +4,7 @@ const mapInstances = {};
 const optionsInstances = {};
 const currentLocationMarkerInstances = {};
 const drawControls = {};
+const editedFeatureIds = {};
 const scaleControlInstances = {};
 /**
  * Cuts the GeoJSON source at the antimeridian if the option is enabled.
@@ -199,7 +200,8 @@ export function addTerraDrawTool(container, options) {
 export function stopTerraDraw(container) {
     const draw = drawControls[container];
     draw.setMode("static");
-    draw.stop()
+    draw.stop();
+    delete editedFeatureIds[container];
 }
 
 /**
@@ -238,6 +240,63 @@ export function setTerraDrawMode(container, mode) {
 }
 
 /**
+ * Add a pre-existing feature into terra-draw's store and put the tool into
+ * select mode so the user can edit the feature's coordinates.
+ *
+ * @param {string} container - The identifier of the map container.
+ * @param {string} featureJson - GeoJSON Feature serialized as a string.
+ * @param {string} mode - The terra-draw mode name ("point" | "linestring" | "polygon").
+ */
+export function editTerraDrawFeature(container, featureJson, mode) {
+    const draw = drawControls[container];
+    if (!draw) {
+        console.error('[editTerraDrawFeature] terra-draw not initialised for container', container);
+        return;
+    }
+    if (!draw._enabled) {
+        draw.start();
+    }
+
+    const feature = JSON.parse(featureJson);
+    feature.type = "Feature";
+    feature.properties = feature.properties || {};
+    feature.properties.mode = mode;
+
+    if (mode === 'linestring' || mode === 'polygon') {
+        draw.updateModeOptions(mode, { showCoordinatePoints: true });
+    }
+    for (const drawingMode of ['linestring', 'polygon']) {
+        if (drawingMode !== mode) {
+            draw.updateModeOptions(drawingMode, { showCoordinatePoints: false });
+        }
+    }
+
+    let result;
+    try {
+        result = draw.addFeatures([feature]);
+    } catch (e) {
+        console.error('[editTerraDrawFeature] addFeatures threw', e, feature);
+        return;
+    }
+
+    const entry = Array.isArray(result) ? result[0] : null;
+    if (entry && entry.valid === false) {
+        console.error('[editTerraDrawFeature] terra-draw rejected feature:', entry.reason, feature);
+        return;
+    }
+
+    draw.setMode('select');
+
+    const id = entry?.id;
+    if (id != null) {
+        editedFeatureIds[container] = id;
+        if (typeof draw.selectFeature === 'function') {
+            try { draw.selectFeature(id); } catch (e) { /* selection is best-effort */ }
+        }
+    }
+}
+
+/**
  * Finish the geometry currently being edited.
  *
  * @param {string} container - The identifier of the map container.
@@ -259,7 +318,12 @@ export function finishGeometry(container) {
 export function getTerraDrawGeometries(container)
 {
     const draw = drawControls[container];
-    return filterInternalFeatures(draw.getSnapshot());
+    const all = draw.getSnapshot();
+    const editedId = editedFeatureIds[container];
+    if (editedId != null) {
+        return all.filter(f => f.id === editedId);
+    }
+    return filterInternalFeatures(all);
 }
 
 /**

--- a/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -217,6 +217,10 @@ export function setTerraDrawMode(container, mode) {
             draw.start();
         }
 
+        if (mode !== 'select' && editedFeatureIds[container] != null) {
+            delete editedFeatureIds[container];
+        }
+
         // Enable coordinate points on the target drawing mode while it is
         // still inactive — mutating an active mode's showCoordinatePoints
         // corrupts its state.
@@ -255,6 +259,12 @@ export function editTerraDrawFeature(container, featureJson, mode) {
     }
     if (!draw._enabled) {
         draw.start();
+    }
+
+    const prevId = editedFeatureIds[container];
+    if (prevId != null) {
+        try { draw.removeFeatures([prevId]); } catch (e) { /* best-effort */ }
+        delete editedFeatureIds[container];
     }
 
     const feature = JSON.parse(featureJson);


### PR DESCRIPTION
Seeds a pre-existing GeoJSON feature into terra-draw and switches into select mode so the user can reshape it. Tracks the seeded feature's internal id so getTerraDrawGeometries returns only the edited feature on save, ignoring select-mode helper points (coordinate, midpoint, selection, etc.).