### PR TITLE
BILL-146 Add singleFeature option to AddTerraDrawToolAsync

### DIFF
--- a/Community.Blazor.MapLibre/MapLibre.razor.cs
+++ b/Community.Blazor.MapLibre/MapLibre.razor.cs
@@ -221,14 +221,19 @@ public partial class MapLibre : ComponentBase, IAsyncDisposable
     /// <summary>
     /// Add a terra-draw instance for drawing geometries
     /// </summary>
-    public async Task AddTerraDrawToolAsync()
+    /// <param name="singleFeature">
+    /// When <c>true</c>, clicking the first/last coordinate no longer closes
+    /// the geometry — commit explicitly via <see cref="FinishGeometryAsync"/>.
+    /// </param>
+    public async Task AddTerraDrawToolAsync(bool singleFeature = false)
     {
+        var options = new { singleFeature };
         if (_bulkTransaction is not null)
         {
-            _bulkTransaction.Add("addTerraDrawTool");
+            _bulkTransaction.Add("addTerraDrawTool", options);
             return;
         }
-        await _jsModule.InvokeVoidAsync("addTerraDrawTool", MapId);
+        await _jsModule.InvokeVoidAsync("addTerraDrawTool", MapId, options);
     }
 
     /// <summary>

--- a/Community.Blazor.MapLibre/MapLibre.razor.js
+++ b/Community.Blazor.MapLibre/MapLibre.razor.js
@@ -144,7 +144,10 @@ export function addNavigationControl(container, options, position) {
  */
 export function addTerraDrawTool(container, options) {
     const map = mapInstances[container];
-    // TODO: Make configurable via options
+    const singleFeature = options?.singleFeature === true;
+    // -1 disables close-on-click. 0 doesn't work — terra-draw 1.26 gates the
+    // option with `if (options?.pointerDistance)` and falls back to the default.
+    const drawModeOpts = singleFeature ? { pointerDistance: -1 } : {};
     var adapter = new terraDrawMaplibreGlAdapter.TerraDrawMapLibreGLAdapter({ map })
     var select = new terraDraw.TerraDrawSelectMode({
         flags: {
@@ -181,6 +184,7 @@ export function addTerraDrawTool(container, options) {
     });
     const polygonMode = new terraDraw.TerraDrawPolygonMode({
         showCoordinatePoints: true,
+        ...drawModeOpts,
         validation: (feature, { updateType }) => {
             if (updateType === "finish" || updateType === "commit") {
                 return terraDraw.ValidateNotSelfIntersecting(feature);
@@ -188,8 +192,12 @@ export function addTerraDrawTool(container, options) {
             return { valid: true }
         }
     })
+    const lineStringMode = new terraDraw.TerraDrawLineStringMode({
+        showCoordinatePoints: true,
+        ...drawModeOpts
+    });
     const deleteMode = new TerraDrawCoordinateDeleteModeUmd();
-    drawControls[container] = new terraDraw.TerraDraw({adapter: adapter, modes: [new terraDraw.TerraDrawFreehandMode(), polygonMode, new terraDraw.TerraDrawLineStringMode({ showCoordinatePoints: true }), select, new terraDraw.TerraDrawPointMode(), deleteMode]})
+    drawControls[container] = new terraDraw.TerraDraw({adapter: adapter, modes: [new terraDraw.TerraDrawFreehandMode(), polygonMode, lineStringMode, select, new terraDraw.TerraDrawPointMode(), deleteMode]});
 }
 
 /**


### PR DESCRIPTION
When enabled, polygon and line drawing no longer close on first/last coordinate click and must be committed via FinishGeometryAsync. Uses terra-draw's pointerDistance: -1 since 0 is gated by a truthy check.